### PR TITLE
Center particle effect when auto trigger is enabled

### DIFF
--- a/src/Ember/EmberContext.cs
+++ b/src/Ember/EmberContext.cs
@@ -122,6 +122,7 @@ public static class EmberContext
         s_contentManager.RootDirectory = ProjectDirectory;
 
         ParticleEffect = new(ProjectName);
+        CenterParticleEffect();
         HasUnsavedChanges = true;
         SaveProject();
     }
@@ -136,6 +137,7 @@ public static class EmberContext
 
         using ParticleEffectReader reader = new(ProjectFilePath, s_contentManager);
         ParticleEffect = reader.ReadParticleEffect();
+        CenterParticleEffect();
     }
 
     public static void SaveProject()
@@ -177,6 +179,16 @@ public static class EmberContext
         }
 
         s_game.Exit();
+    }
+
+    public static void CenterParticleEffect()
+    {
+        if (ParticleEffect == null)
+        {
+            return;
+        }
+
+        ParticleEffect.Position = s_graphicsDevice.Viewport.Bounds.Center.ToVector2();
     }
 
     public static void AddEmitter()

--- a/src/Ember/EmberEditor.cs
+++ b/src/Ember/EmberEditor.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 // See LICENSE file in the project root for full license information.
 
+using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
@@ -43,8 +44,14 @@ public class EmberEditor : Game
         _graphics.ApplyChanges();
 
         Window.AllowUserResizing = true;
+        Window.ClientSizeChanged += OnClientSizeChanged;
         Content.RootDirectory = "Content";
         IsMouseVisible = true;
+    }
+
+    private void OnClientSizeChanged(object sender, EventArgs e)
+    {
+        EmberContext.CenterParticleEffect();
     }
 
     protected override unsafe void Initialize()


### PR DESCRIPTION
## Description

Fixes particle effect positioning bug where auto-triggered emitters remained at (0,0) in the top-right corner behind the properties panel, making them invisible to users.

## Related Issues/Tickets

* Closes #1 

## Changes Made

* Added `CenterParticleEffect()` method to `EmberContext` that positions the particle effect at the viewport center
* Modified `CreateProject()` and `OpenProject()` methods to call `CenterParticleEffect()` after particle effect initialization
* Added event handler for `Window.ClientSizeChanged` in `EmberEditor` to automatically recenter the effect when the window is resized
* Ensures auto-triggered particle emitters are visible in the main viewport area instead of being hidden behind UI panels

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.