### PR TITLE
Use assembly version instead of file version

### DIFF
--- a/src/Ember/EmberEditor.cs
+++ b/src/Ember/EmberEditor.cs
@@ -25,7 +25,8 @@ public class EmberEditor : Game
 {
     private static EmberEditor s_instance;
     private static readonly CompositeFormat s_windowTitle = CompositeFormat.Parse("Ember: {0} | {1:F3} ms/Frame | {2:F1} FPS");
-    private static readonly string s_version = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).FileVersion;
+    private static readonly string s_version = Assembly.GetExecutingAssembly().GetName().Version?.ToString();
+
     private static float s_frameRate;
 
     private readonly GraphicsDeviceManager _graphics;


### PR DESCRIPTION
## Description

Uses the assembly version directly instead of file version. This was causing an exception in single file published binaries.

## Related Issues/Tickets

- Closes #6 

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
