### PR TITLE
Fix issue with release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,10 @@ jobs:
       - name: Install MonoPack
         run: dotnet tool install -g MonoPack
 
+      - name: Create Package Directory
+        shell: bash
+        run: mkdir -p ./${{ matrix.artifact }}
+
       - name: Package
         shell: bash
         env:


### PR DESCRIPTION
## Description

Release workflow is breaking due to directory not existing? Might be a Monopack issue, but creating directory manually for now just in case.

## Related Issues/Tickets

- None

## Changes Made

- Added Create Package Directory step in workflow

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
