### PR TITLE
Fix issue where create directory button would not work when director name was valid

### DIFF
--- a/src/Ember/UI/Modals/CreateDirectoryModal.cs
+++ b/src/Ember/UI/Modals/CreateDirectoryModal.cs
@@ -108,7 +108,7 @@ public static class CreateDirectoryModal
                 ImGui.Spacing();
             }
 
-            ImGui.BeginDisabled(isDirectoryNameValid);
+            ImGui.BeginDisabled(!isDirectoryNameValid);
             if (ImGui.Button(SR.Popup_CreateDirectoryModal_CreateDirectory_Label))
             {
                 try


### PR DESCRIPTION
## Description

Resolves issue where the "Create Directory" button would be greyed out even when the directory name is valid.

## Related Issues/Tickets

* Closes #10 

## Changes Made

* Changed the `ImGui.BeginDisabled()` parameter from `isValidDirectory` to `!isValidDirectory` to correctly disable the button only when the directory is not valid.

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
