### PR TITLE
Clear context when creating or opening project

### DIFF
--- a/src/Ember/EmberContext.cs
+++ b/src/Ember/EmberContext.cs
@@ -174,6 +174,10 @@ public static class EmberContext
         SelectedInterpolator = null;
         SelectedInterpolatorIndex = -1;
         CurrentInterpolators = null;
+        s_emitterLocks.Clear();
+        s_modifierLocks.Clear();
+        s_interpolatorLocks.Clear();
+        s_textureCache.Clear();
 
         GC.Collect();
     }

--- a/src/Ember/EmberContext.cs
+++ b/src/Ember/EmberContext.cs
@@ -106,6 +106,8 @@ public static class EmberContext
         ArgumentException.ThrowIfNullOrWhiteSpace(projectName);
         ArgumentException.ThrowIfNullOrWhiteSpace(projectDirectory);
 
+        ClearContext();
+
         ProjectName = projectName;
         ProjectDirectory = projectDirectory;
 
@@ -131,6 +133,8 @@ public static class EmberContext
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
 
+        ClearContext();
+
         ProjectName = Path.GetFileNameWithoutExtension(filePath);
         ProjectDirectory = Path.GetDirectoryName(filePath);
         ProjectFilePath = filePath;
@@ -151,6 +155,27 @@ public static class EmberContext
         writer.WriteParticleEffect(ParticleEffect);
 
         HasUnsavedChanges = false;
+    }
+
+    private static void ClearContext()
+    {
+        if (ParticleEffect != null)
+        {
+            ParticleEffect.Dispose();
+            ParticleEffect = null;
+        }
+
+        s_contentManager.Unload();
+
+        SelectedParticleEmitter = null;
+        SelectedParticleEmitterIndex = -1;
+        SelectedModifier = null;
+        SelectedModifierIndex = -1;
+        SelectedInterpolator = null;
+        SelectedInterpolatorIndex = -1;
+        CurrentInterpolators = null;
+
+        GC.Collect();
     }
 
     public static void Exit()


### PR DESCRIPTION
## Description

Resolves issue where the context was not being cleared when creating or opening a project while an existing project was already opened.

## Related Issues/Tickets

* Closes #11 

## Changes Made

* Added `EmberContext.ClearContext()` method which disposes of an existing `ParticleEffect` instance if there is one, unloads content from the content manger, and resets the internal state tracking objects.
* Call new `EmberContext.ClearContext()` method when creating a new project or opening a project.

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
