### PR TITLE
Set content manager root directory when opening project

### DIFF
--- a/src/Ember/EmberContext.cs
+++ b/src/Ember/EmberContext.cs
@@ -139,6 +139,8 @@ public static class EmberContext
         ProjectDirectory = Path.GetDirectoryName(filePath);
         ProjectFilePath = filePath;
 
+        s_contentManager.RootDirectory = ProjectDirectory;
+
         using ParticleEffectReader reader = new(ProjectFilePath, s_contentManager);
         ParticleEffect = reader.ReadParticleEffect();
         CenterParticleEffect();


### PR DESCRIPTION
## Description

When opening an existing project, the content manager root directory was not being set. This PR resolves it by setting it to the project directory of the project that was opened.

## Related Issues/Tickets

* Closes #12 

## Changes Made

* Set the content manager root path when opening an existing project to the project's directory

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
