### PR TITLE
Fix shared texture causing first emitter to lose its texture

### DIFF
--- a/src/Ember/Architecture/Views/ParticleEffectView.cs
+++ b/src/Ember/Architecture/Views/ParticleEffectView.cs
@@ -1147,21 +1147,29 @@ public sealed class ParticleEffectView
             FileDialog dialog = FileDialog.GetFileDialog(this, null, ".png");
             if (dialog.Draw())
             {
-                string fileName = Path.GetFileName(dialog.SelectedItem.FullName);
+                string filePath = dialog.SelectedItem.FullName;
+                string fileName = Path.GetFileName(filePath);
 
-                // Check if this texture already exists in the project
-                if (_context.TextureExists(fileName))
+                if (_context.IsRelativeTo(filePath))
                 {
-                    _pendingTextureFilePath = dialog.SelectedItem.FullName;
+                    // File is already inside the project directory (previously imported).
+                    // Reuse the cached texture without copying or prompting.
+                    _context.AddTexture(filePath);
+                    AssignTextureToSelectedEmitter(fileName);
+                }
+                else if (_context.TextureExists(fileName))
+                {
+                    // A different source file from outside the project shares the
+                    // same filename as an already-imported texture. Prompt to overwrite.
+                    _pendingTextureFilePath = filePath;
                     _confirmOverwrite = true;
                 }
                 else
                 {
-                    // No conflict, add directly
-                    _context.AddTexture(dialog.SelectedItem.FullName);
+                    // New texture from outside the project directory. Copy and load.
+                    _context.AddTexture(filePath);
                     AssignTextureToSelectedEmitter(fileName);
                 }
-
             }
             EndPopup();
         }


### PR DESCRIPTION
## Description

Fixes a bug where selecting the same texture file for a second emitter would cause the first emitter to lose its texture in the live preview. The first emitter would appear broken until the file was closed and reopened.

## Related Issues/Tickets

- Closes #28 

## Changes Made

- Updated `DrawSelectTexturePopup` in `ParticleEffectView.cs` to check  `IsRelativeTo` before `TextureExists` when a texture is selected from the file dialog.
- Files already inside the project directory (previously imported textures) now skip the copy and overwrite path entirely and reuse the existing cached `Texture2D` instance directly.
- The overwrite confirmation dialog is now only shown when a file from outside the project directory conflicts by filename with an already imported texture, which is the only case where overwriting is meaningful

## Checklist

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
