### PR TITLE
Default file dialogs to project directory and remember last used location

### DIFF
--- a/src/Ember/Architecture/EditorContext.cs
+++ b/src/Ember/Architecture/EditorContext.cs
@@ -48,6 +48,9 @@ public sealed class EditorContext : IDisposable
     public string ProjectDirectory { get; private set; } = string.Empty;
     public string ProjectFilePath { get; private set; } = string.Empty;
 
+    public string LastUsedTextureDirectory { get; set; } = string.Empty;
+    public string LastUsedProjectDirectory { get; set; } = string.Empty;
+
     public bool HasUnsavedChanges { get; set; }
     public bool IsProjectOpen => ParticleEffect != null;
     public bool IsProjectPaused { get; private set; } = false;
@@ -673,6 +676,9 @@ public sealed class EditorContext : IDisposable
         SetWorkingDirectory(ProjectDirectory);
         _contentManager.RootDirectory = ProjectDirectory;
 
+        LastUsedTextureDirectory = ProjectDirectory;
+        LastUsedProjectDirectory = ProjectDirectory;
+
         ParticleEffect = new ParticleEffect(ProjectName);
 
         CenterParticleEffect();
@@ -693,6 +699,9 @@ public sealed class EditorContext : IDisposable
 
         SetWorkingDirectory(ProjectDirectory);
         _contentManager.RootDirectory = ProjectDirectory;
+
+        LastUsedTextureDirectory = ProjectDirectory;
+        LastUsedProjectDirectory = ProjectDirectory;
 
         ParticleEffect = ParticleEffectSerializer.Deserialize(ProjectFilePath, _contentManager);
         CenterParticleEffect();

--- a/src/Ember/Architecture/Views/MainMenuBarView.cs
+++ b/src/Ember/Architecture/Views/MainMenuBarView.cs
@@ -222,9 +222,10 @@ public sealed class MainMenuBarView
 
         if (BeginPopupModal("open-project"u8, modalFlags))
         {
-            FileDialog dialog = FileDialog.GetFileDialog(this, null, ".ember");
+            FileDialog dialog = FileDialog.GetFileDialog(this, _context.LastUsedProjectDirectory, ".ember");
             if (dialog.Draw())
             {
+                _context.LastUsedProjectDirectory = Path.GetDirectoryName(dialog.SelectedItem.FullName);
                 _context.RequestOpenProject(dialog.SelectedItem.FullName);
             }
             EndPopup();

--- a/src/Ember/Architecture/Views/ParticleEffectView.cs
+++ b/src/Ember/Architecture/Views/ParticleEffectView.cs
@@ -1144,11 +1144,13 @@ public sealed class ParticleEffectView
 
         if (BeginPopupModal("select-texture"u8, modalFlags))
         {
-            FileDialog dialog = FileDialog.GetFileDialog(this, null, ".png");
+            FileDialog dialog = FileDialog.GetFileDialog(this, _context.LastUsedTextureDirectory, ".png");
             if (dialog.Draw())
             {
                 string filePath = dialog.SelectedItem.FullName;
                 string fileName = Path.GetFileName(filePath);
+
+                _context.LastUsedTextureDirectory = Path.GetDirectoryName(filePath);
 
                 if (_context.IsRelativeTo(filePath))
                 {


### PR DESCRIPTION
## Description

The texture picker and open project file dialogs always opened at the user's home directory, regardless of where the project or its assets were located. For users with assets on a different drive or in a deeply nested directory this required many clicks on every open. 

The dialogs now default to the current project directory and remember the last navigated location between opens.

## Related Issues/Tickets

- Closes #29 

## Changes Made

* Added `LastUsedTextureDirectory` and `LastUsedProjectDirectory` properties to `EditorContext`. 
* `DrawSelectTexturePopup` in `ParticleEffectView.cs` now passes `LastUsedTextureDirectory` as the start path when requesting the file dialog, and updates it to the directory of the selected texture after a successful pick.
* `DrawOpenProjectPopup` in `MainMenuBarView.cs` now passes `LastUsedProjectDirectory` as the start path and updates it after a project is selected.

## Checklist

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
