### PR TITLE
Store texture as relative path reference instead of copying into project

### DIFF
--- a/src/Ember/Architecture/Components/PropertyTable.cs
+++ b/src/Ember/Architecture/Components/PropertyTable.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Text;
 using Ember.Graphics;
 using Hexa.NET.ImGui;
@@ -250,21 +251,15 @@ public static class PropertyTable
 
         if (region != null)
         {
-            ReadOnlySpan<byte> name;
-            if (!string.IsNullOrEmpty(region.Name))
-            {
-                name = Encoding.UTF8.GetBytes(region.Name);
-            }
-            else if (!string.IsNullOrEmpty(region.Texture.Name))
-            {
-                name = Encoding.UTF8.GetBytes(region.Texture.Name);
-            }
-            else
-            {
-                name = "Texture"u8;
-            }
+            string texturePath = !string.IsNullOrEmpty(region.Texture.Name)
+                                  ? region.Texture.Name
+                                  : region.Name;
 
-            if (Button(name, -SysVec2.UnitX))
+            string displayName = !string.IsNullOrEmpty(texturePath)
+                                  ? Path.GetFileName(texturePath)
+                                  : "Texture";
+
+            if (Button(Encoding.UTF8.GetBytes(displayName), -SysVec2.UnitX))
             {
                 clicked = true;
             }
@@ -301,6 +296,12 @@ public static class PropertyTable
                     };
 
                     Image(textureRef, previewSize, uv0, uv1);
+
+                    if (!string.IsNullOrEmpty(texturePath))
+                    {
+                        TextDisabled(texturePath);
+                    }
+
                     EndTooltip();
                 }
             }

--- a/src/Ember/Architecture/EditorContext.cs
+++ b/src/Ember/Architecture/EditorContext.cs
@@ -559,81 +559,39 @@ public sealed class EditorContext : IDisposable
     public string GetWorkingDirectory() => Directory.GetCurrentDirectory();
     public void SetWorkingDirectory(string directory) => Directory.SetCurrentDirectory(directory);
 
-    public string CopyTo(string filePath, bool overwrite = false)
-    {
-        ArgumentException.ThrowIfNullOrEmpty(filePath);
-
-        string sourceName = Path.GetFileName(filePath);
-        string destination = Path.Combine(GetWorkingDirectory(), sourceName);
-        File.Copy(filePath, destination, overwrite);
-        return destination;
-    }
-
     public string GetRelativePath(string filePath) => Path.GetRelativePath(GetWorkingDirectory(), filePath);
 
-    public bool IsRelativeTo(string filePath)
-    {
-        string relativePath = GetRelativePath(filePath);
-        return !relativePath.StartsWith('.');
-    }
+    public bool TextureExists(string relativePath) => _textureCache.ContainsKey(relativePath);
 
-    public bool TextureExists(string fileName) => _textureCache.ContainsKey(fileName);
-
-    public void AddTexture(string filePath, bool overwrite = false)
+    public void AddTexture(string filePath)
     {
         ArgumentException.ThrowIfNullOrEmpty(filePath);
 
-        string fileName = Path.GetFileName(filePath);
+        string relativePath = GetRelativePath(filePath);
 
-        // If already in project directory, just load it
-        if (IsRelativeTo(filePath))
+        if (TextureExists(relativePath))
         {
-            if (overwrite || !TextureExists(fileName))
-            {
-                LoadTexture(fileName);
-            }
             return;
         }
 
-        string destinationPath = Path.Combine(GetWorkingDirectory(), fileName);
-
-        // Check if file exists and whether we should overwrite
-        if (File.Exists(destinationPath) && !overwrite)
-        {
-            // File exists but we're not overwriting, so just ensure it's loaded
-            if (!TextureExists(fileName))
-            {
-                LoadTexture(fileName);
-            }
-            return;
-        }
-
-        // Copy and load texture
-        CopyTo(filePath, overwrite: true);
-        LoadTexture(fileName);
+        LoadTexture(filePath, relativePath);
     }
 
-    public Texture2D LoadTexture(string fileName)
+    private Texture2D LoadTexture(string absolutePath, string relativePath)
     {
-        ArgumentException.ThrowIfNullOrEmpty(fileName);
+        ArgumentException.ThrowIfNullOrEmpty(absolutePath);
+        ArgumentException.ThrowIfNullOrEmpty(relativePath);
 
-        // If already cached, unload and reload
-        if (_textureCache.TryGetValue(fileName, out Texture2D cached))
-        {
-            cached.Dispose();
-            _textureCache.Remove(fileName);
-        }
-
-        Texture2D texture = Texture2D.FromFile(_graphicsDevice, fileName);
-        texture.Name = fileName;
-        _textureCache[fileName] = texture;
+        Texture2D texture = Texture2D.FromFile(_graphicsDevice, absolutePath);
+        texture.Name = relativePath;
+        _textureCache[relativePath] = texture;
 
         return texture;
     }
 
-    public Texture2D GetTexture(string fileName)
+    public Texture2D GetTexture(string relativePath)
     {
-        if (_textureCache.TryGetValue(fileName, out Texture2D texture))
+        if (_textureCache.TryGetValue(relativePath, out Texture2D texture))
         {
             return texture;
         }

--- a/src/Ember/Architecture/Views/ParticleEffectView.cs
+++ b/src/Ember/Architecture/Views/ParticleEffectView.cs
@@ -7,6 +7,7 @@ using MonoGame.Extended;
 using MonoGame.Extended.Graphics;
 using MonoGame.Extended.Particles;
 using MonoGame.Extended.Particles.Data;
+using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Extended.Particles.Profiles;
 using static Hexa.NET.ImGui.ImGui;
 
@@ -21,8 +22,6 @@ public sealed class ParticleEffectView
     private int _emitterDragFromIndex = -1;
     private int _emitterDragToIndex = -1;
     private bool _selectTexture;
-    private string _pendingTextureFilePath = string.Empty;
-    private bool _confirmOverwrite;
     private HslColor _userFromColor;
     private HslColor _userToColor;
     private bool _isColorReleaseParameterInitialized;
@@ -52,7 +51,6 @@ public sealed class ParticleEffectView
         End();
 
         DrawSelectTexturePopup();
-        DrawOverwriteConfirmationPopup();
     }
 
     private void DrawParticleEffectProperties()
@@ -1148,90 +1146,17 @@ public sealed class ParticleEffectView
             if (dialog.Draw())
             {
                 string filePath = dialog.SelectedItem.FullName;
-                string fileName = Path.GetFileName(filePath);
+                string relativePath = _context.GetRelativePath(filePath);
 
                 _context.LastUsedTextureDirectory = Path.GetDirectoryName(filePath);
-
-                if (_context.IsRelativeTo(filePath))
-                {
-                    // File is already inside the project directory (previously imported).
-                    // Reuse the cached texture without copying or prompting.
-                    _context.AddTexture(filePath);
-                    AssignTextureToSelectedEmitter(fileName);
-                }
-                else if (_context.TextureExists(fileName))
-                {
-                    // A different source file from outside the project shares the
-                    // same filename as an already-imported texture. Prompt to overwrite.
-                    _pendingTextureFilePath = filePath;
-                    _confirmOverwrite = true;
-                }
-                else
-                {
-                    // New texture from outside the project directory. Copy and load.
-                    _context.AddTexture(filePath);
-                    AssignTextureToSelectedEmitter(fileName);
-                }
+                _context.AddTexture(filePath);
+                AssignTextureToSelectedEmitter(relativePath);
             }
             EndPopup();
         }
     }
 
-    private void DrawOverwriteConfirmationPopup()
-    {
-        if (_confirmOverwrite)
-        {
-            OpenPopup("confirm-overwrite"u8);
-            _confirmOverwrite = false;
-        }
-
-        ImGuiViewportPtr viewportPtr = GetMainViewport();
-        SysVec2 workCenter = viewportPtr.WorkPos + (viewportPtr.WorkSize * 0.5f);
-
-        SetNextWindowPos(workCenter, ImGuiCond.Always, new SysVec2(0.5f));
-        SetNextWindowSizeConstraints(new SysVec2(400, 0), viewportPtr.WorkSize);
-
-        ImGuiWindowFlags modalFlags = ImGuiWindowFlags.Modal
-                                      | ImGuiWindowFlags.AlwaysAutoResize
-                                      | ImGuiWindowFlags.NoResize
-                                      | ImGuiWindowFlags.NoCollapse
-                                      | ImGuiWindowFlags.NoMove;
-
-        if (BeginPopupModal("confirm-overwrite"u8, modalFlags))
-        {
-            string fileName = Path.GetFileName(_pendingTextureFilePath);
-            Text($"A texture named '{fileName}' already exists.");
-            Spacing();
-            Text("Do you want to overwrite it?"u8);
-            Spacing();
-            Spacing();
-
-            ImGuiStylePtr stylePtr = GetStyle();
-            SysVec2 buttonSize = new SysVec2(100.0f, 0);
-            float widthNeeded = (buttonSize.X * 2) + stylePtr.ItemSpacing.X;
-            float cursorX = GetCursorPosX() + GetContentRegionAvail().X - widthNeeded;
-            SetCursorPosX(cursorX);
-
-            if (Button("Yes"u8, buttonSize))
-            {
-                _context.AddTexture(_pendingTextureFilePath, overwrite: true);
-                AssignTextureToSelectedEmitter(fileName);
-                _pendingTextureFilePath = null;
-                CloseCurrentPopup();
-            }
-
-            SameLine();
-            if (Button("No"u8, buttonSize))
-            {
-                _pendingTextureFilePath = null;
-                CloseCurrentPopup();
-            }
-
-            EndPopup();
-        }
-    }
-
-    private void AssignTextureToSelectedEmitter(string fileName)
+    private void AssignTextureToSelectedEmitter(string relativePath)
     {
         ParticleEmitter emitter = _context.SelectedEmitter;
         if (emitter == null)
@@ -1239,7 +1164,7 @@ public sealed class ParticleEffectView
             return;
         }
 
-        var texture = _context.GetTexture(fileName);
+        Texture2D texture = _context.GetTexture(relativePath);
         if (texture != null)
         {
             emitter.TextureRegion = new Texture2DRegion(texture, texture.Bounds);


### PR DESCRIPTION
## Description

Previously, selecting a texture in the editor would copy it into the project directory. The `.ember` file then stored only the bare filename, requiring the texture to live alongside the `.ember` file at runtime. This made it impossible to reference textures in other directories (e.g., a shared spritesheet used by both particle effects and Tiled maps) without maintaining duplicate copies.

Textures are now referenced by a path relative to the `.ember` file and are never copied. A spritesheet at `Content\maps\spritesheet.png` can be referenced from `Content\particles\effect.ember` as `..\maps\spritesheet.png` with no duplication.

## Related Issues/Tickets

- Closes #30 

## Changes Made

- Removed `CopyTo` and `IsRelativeTo` from `EditorContext`. Texture files are no longer copied into the project directory on import.
-  `AddTexture` now generates the path of the selected file relative to the project directory via `GetRelativePath` and uses that as both the cache key and the value stored in `Texture2D.Name`. This is what the serializer writes to the `Name` attribute in the `.ember` XML, and what it resolves back on load.
- `LoadTexture` is now private and takes an absolute path for loading and a relative path for naming. The cache is keyed by relative path, so textures from different directories that share a filename are treated as distinct entries and never conflict.
- The overwrite confirmation dialog in `ParticleEffectView` has been removed entirely. With path keyed caching, filename conflicts between files in different directories cannot occur, and selecting the same file twice simply hits the cache.
- The texture button in `PropertyTable.TextureProperty` now displays only the filename via `Path.GetFileName`, keeping the label short. The full relative path is shown in a dimmed line below the image preview in the hover tooltip for reference when needed.

## Checklist

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
