### PR TITLE
Changed `X` to `Y` to correct typo in random release parameter

### DIFF
--- a/src/Ember/Architecture/Components/PropertyTable.cs
+++ b/src/Ember/Architecture/Components/PropertyTable.cs
@@ -708,7 +708,7 @@ public static class PropertyTable
         SameLine();
         SetNextItemWidth(dragWidth);
         float maxY = max.Y;
-        if (DragFloat("##max-y"u8, ref maxY, 0.1f, min.Y, float.MaxValue, "X: %.2f"u8))
+        if (DragFloat("##max-y"u8, ref maxY, 0.1f, min.Y, float.MaxValue, "Y: %.2f"u8))
         {
             max.Y = maxY;
             changed = true;


### PR DESCRIPTION
## Description

Random particle release parameter's incorrectly labeled the second Y value as X

## Related Issues/Tickets

- Closes #27 

## Changes Made

- Updated label from `X` to `Y` in `ReleaseParameterRandomVector2`

## Checklist

Please read and check the following items.  Pull requests will not be reviewed if all items are not checked.

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
