### PR TITLE
Fix crash when modifier Frequency is dragged to zero

### DIFF
--- a/src/Ember/Architecture/Views/ModifiersView.cs
+++ b/src/Ember/Architecture/Views/ModifiersView.cs
@@ -217,7 +217,7 @@ public sealed class ModifiersView
 
                     // Frequency property
                     float modifierFrequency = modifier.Frequency;
-                    if (PropertyTable.DragFloatProperty("Frequency"u8, "How often, in times per second, the modifier attempts to update the particle buffer"u8, ref modifierFrequency, 0.1f, 0.0f, float.MaxValue))
+                    if (PropertyTable.DragFloatProperty("Frequency"u8, "How often, in times per second, the modifier attempts to update the particle buffer"u8, ref modifierFrequency, 0.1f, 0.1f, float.MaxValue))
                     {
                         modifier.Frequency = modifierFrequency;
                         _context.HasUnsavedChanges = true;


### PR DESCRIPTION
## Description

Fixes a crash reported when the Frequency property of any modifier is set to zero. The `Modifier.Frequency` setter throws `ArgumentOutOfRangeException` for any value less than or equal to zero, and a value of zero would also cause a division by zero when computing `_cycleTime = 1f / _frequency`.

 The drag control in the editor was using a minimum of `0.0f`, allowing the user to reach the invalid value through normal interaction.

## Related Issues/Tickets

* Closes #23

## Changes Made

- Changed the `min` argument on the Frequency `DragFloatProperty` call in `ModifiersView.cs` from `0.0f` to `0.1f`, matching the drag step size and ensuring the control cannot produce a value that violates the setter's contract.

## Checklist

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
