### PR TITLE
Feature/26 uniform scale for particles

### DIFF
--- a/examples/EmberExample/.config/dotnet-tools.json
+++ b/examples/EmberExample/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.4",
+      "version": "3.8.4.1",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.4",
+      "version": "3.8.4.1",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.4",
+      "version": "3.8.4.1",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.4",
+      "version": "3.8.4.1",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.4",
+      "version": "3.8.4.1",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/examples/EmberExample/Content/Content.mgcb
+++ b/examples/EmberExample/Content/Content.mgcb
@@ -10,6 +10,7 @@
 
 #-------------------------------- References --------------------------------#
 
+/reference:..\..\..\external\monogame-extended\.artifacts\source\bin\MonoGame.Extended.Content.Pipeline\release\MonoGame.Extended.Content.Pipeline.dll
 
 #---------------------------------- Content ---------------------------------#
 
@@ -20,7 +21,9 @@
 /copy:loadtest/Pixel.png
 
 #begin ring/ring.ember
-/copy:ring/ring.ember
+/importer:
+/processor:
+/build:ring/ring.ember
 
 #begin ring/Ring.png
 /copy:ring/Ring.png
@@ -36,3 +39,4 @@
 
 #begin spark/spark.ember
 /copy:spark/spark.ember
+

--- a/examples/EmberExample/EmberExample.csproj
+++ b/examples/EmberExample/EmberExample.csproj
@@ -25,8 +25,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Hexa.NET.ImGui" Version="2.2.8.5" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\external\monogame-extended\source\MonoGame.Extended\MonoGame.Extended.csproj" />

--- a/examples/EmberExample/Game1.cs
+++ b/examples/EmberExample/Game1.cs
@@ -127,8 +127,7 @@ public class Game1 : Game
                 ImGui.TableNextColumn();
                 if (ImGui.Button("Ring"u8, new System.Numerics.Vector2(-1, 0)))
                 {
-                    string fileName = Path.Combine(_contentPath, "ring", "ring.ember");
-                    LoadParticleEffect(fileName);
+                    LoadParticleEffect("ring/ring", true);
                 }
 
                 ImGui.TableNextColumn();
@@ -156,7 +155,7 @@ public class Game1 : Game
                 ImGui.Text("Auto Trigger: ");
                 ImGui.TableNextColumn();
                 bool autoTrigger = _particleEffect.AutoTrigger;
-                if(ImGui.Checkbox("##auto_trigger"u8, ref autoTrigger))
+                if (ImGui.Checkbox("##auto_trigger"u8, ref autoTrigger))
                 {
                     _particleEffect.AutoTrigger = autoTrigger;
                 }
@@ -213,7 +212,7 @@ public class Game1 : Game
         ImGuiRenderer.AfterLayout();
     }
 
-    private void LoadParticleEffect(string fileName)
+    private void LoadParticleEffect(string fileName, bool useContentPipeline = false)
     {
         if (_particleEffect != null)
         {
@@ -221,9 +220,16 @@ public class Game1 : Game
             _particleEffect = null;
         }
 
-        using ParticleEffectReader reader = new(fileName, Content);
-        _particleEffect = reader.ReadParticleEffect();
-        _particleEffect.Position = GraphicsDevice.Viewport.Bounds.Center.ToVector2();
-        _particleEffect.AutoTrigger = false;
+        if (useContentPipeline)
+        {
+            _particleEffect = Content.Load<ParticleEffect>(fileName);
+        }
+        else
+        {
+            using ParticleEffectReader reader = new(fileName, Content);
+            _particleEffect = reader.ReadParticleEffect();
+            _particleEffect.Position = GraphicsDevice.Viewport.Bounds.Center.ToVector2();
+            _particleEffect.AutoTrigger = false;
+        }
     }
 }

--- a/src/Ember/Architecture/Components/PropertyTable.cs
+++ b/src/Ember/Architecture/Components/PropertyTable.cs
@@ -471,9 +471,36 @@ public static class PropertyTable
         }
         else if (value.Kind == ParticleValueKind.Random)
         {
-            if (ReleaseParameterRandomVector2(ref value.RandomMin, ref value.RandomMax))
+            TableNextColumn();
+            bool uniform = value.Uniform;
+            if (Checkbox("Uniform##uniform"u8, ref uniform))
             {
+                value.Uniform = uniform;
+                if (uniform)
+                {
+                    value.RandomMin.Y = value.RandomMin.X;
+                    value.RandomMax.Y = value.RandomMax.X;
+                }
                 changed = true;
+            }
+
+            TableNextRow();
+            TableNextColumn();
+            TableNextColumn();
+
+            if (value.Uniform)
+            {
+                if (ReleaseParameterUniformRandomVector2(ref value.RandomMin, ref value.RandomMax))
+                {
+                    changed = true;
+                }
+            }
+            else
+            {
+                if (ReleaseParameterRandomVector2(ref value.RandomMin, ref value.RandomMax))
+                {
+                    changed = true;
+                }
             }
         }
 
@@ -651,6 +678,43 @@ public static class PropertyTable
         if (DragFloat("##constant-y"u8, ref y, 0.1f, 0.0f, float.MaxValue, "Y: %.2f"u8))
         {
             value.Y = y;
+            changed = true;
+        }
+
+        return changed;
+    }
+
+    private static bool ReleaseParameterUniformRandomVector2(ref XnaVec2 min, ref XnaVec2 max)
+    {
+        bool changed = false;
+
+        ImGuiStylePtr stylePtr = GetStyle();
+        TableNextColumn();
+
+        float availWidth = GetContentRegionAvail().X;
+        float toWidth = CalcTextSize(" to "u8).X;
+        float spacing = stylePtr.ItemSpacing.X * 2.0f;
+        float dragWidth = (availWidth - toWidth - spacing) * 0.5f;
+
+        SetNextItemWidth(dragWidth);
+        float minVal = min.X;
+        if (DragFloat("##uniform-min"u8, ref minVal, 0.1f, 0.0f, max.X, "%.2f"u8))
+        {
+            min.X = minVal;
+            min.Y = minVal;
+            changed = true;
+        }
+
+        SameLine();
+        Text(" to "u8);
+
+        SameLine();
+        SetNextItemWidth(dragWidth);
+        float maxVal = max.X;
+        if (DragFloat("##uniform-max"u8, ref maxVal, 0.1f, min.X, float.MaxValue, "%.2f"u8))
+        {
+            max.X = maxVal;
+            max.Y = maxVal;
             changed = true;
         }
 


### PR DESCRIPTION
## Description

Adds a Uniform toggle to the Scale release parameter when Kind is set to Random. Without this, X and Y scale are sampled independently, meaning particles can receive non uniform aspect ratios even when the range appears symmetric. When Uniform is enabled, both axes share the same sampled value

## Related Issues/Tickets

* Closes #26
* https://github.com/MonoGame-Extended/Monogame-Extended/pull/1130

## Changes Made

- `PropertyTable.cs`: updated `ReleaseParameter(ref ParticleVector2Parameter)` to show a Uniform checkbox in the Random branch. 

## Checklist

* [x] I have verified that there are no existing pull requests that would overlap with this pull request.
* [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
* [x] I have verified that this pull request adheres to this project's code of conduct.
* [x] I have written a descriptive title for this pull request.
* [x] I have provided appropriate test coverage were applicable.
